### PR TITLE
zoho API integration for lead push from registration

### DIFF
--- a/satellite/console/consoleweb/consoleapi/auth.go
+++ b/satellite/console/consoleweb/consoleapi/auth.go
@@ -233,6 +233,12 @@ func (a *Auth) Register(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if r.URL.Query().Has("zoho-insert") {
+		a.log.Debug("inserting lead in Zoho CRM")
+		// Inserting lead in Zoho CRM
+		go zohoInsertLead(ctx, registerData.FullName, registerData.Email, a.log)
+	}
+
 	// trim leading and trailing spaces of email address.
 	registerData.Email = strings.TrimSpace(registerData.Email)
 

--- a/satellite/console/consoleweb/consoleapi/zoho.go
+++ b/satellite/console/consoleweb/consoleapi/zoho.go
@@ -1,0 +1,181 @@
+package consoleapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"go.uber.org/atomic"
+	"go.uber.org/zap"
+)
+
+const (
+	zoho_DefaultLeadSource = "register"
+	zoho_RefreshTokenFreq  = 45 * time.Minute
+
+	zoho_RefreshTokenURL = "https://accounts.zoho.in/oauth/v2/token"
+	zoho_GrantType       = "refresh_token"
+)
+
+var token atomic.String
+
+func ZohoRefreshTokenInit(ctx context.Context, clientID, clientSecret, refreshToken string, log *zap.Logger) {
+	log = log.Named("zoho_refresh_token")
+
+	if clientID == "" || clientSecret == "" || refreshToken == "" {
+		log.Warn("zohoRefreshTokenInit: missing clientID, clientSecret or refreshToken")
+		return
+	}
+
+	for {
+		log.Debug("zohoRefreshToken started")
+		err := zohoRefreshToken(ctx, clientID, clientSecret, refreshToken)
+		if err != nil {
+			log.Error("zohoRefreshToken", zap.Error(err))
+			time.Sleep(time.Second)
+			continue
+		}
+
+		log.Debug("zohoRefreshToken success")
+
+		time.Sleep(zoho_RefreshTokenFreq)
+	}
+}
+
+func zohoRefreshToken(ctx context.Context, clientID, clientSecret, refreshToken string) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			switch r := r.(type) {
+			case error:
+				err = r
+			default:
+				err = fmt.Errorf("%v", r)
+			}
+		}
+	}()
+
+	client := &http.Client{}
+
+	req, err := http.NewRequest(http.MethodPost, zoho_RefreshTokenURL, nil)
+	if err != nil {
+		return err
+	}
+
+	q := req.URL.Query()
+	q.Add("refresh_token", refreshToken)
+	q.Add("client_id", clientID)
+	q.Add("client_secret", clientSecret)
+	q.Add("grant_type", zoho_GrantType)
+	req.URL.RawQuery = q.Encode()
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	type zohoRefreshTokenResponse struct {
+		AccessToken string `json:"access_token"`
+		APIDomain   string `json:"api_domain"`
+		TokenType   string `json:"token_type"`
+		ExpiresIn   int    `json:"expires_in"`
+	}
+
+	response := &zohoRefreshTokenResponse{}
+	err = json.NewDecoder(resp.Body).Decode(response)
+	if err != nil {
+		return err
+	}
+
+	// storing access token in atomic.String for thread safety
+	token.Store(response.AccessToken)
+
+	return nil
+}
+
+func zohoInsertLead(ctx context.Context, fullname, email string, log *zap.Logger) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Error("zohoInsertLead: panic", zap.Any("panic", r))
+		}
+	}()
+
+	if token.String() == "" {
+		log.Warn("zohoInsertLead: token is empty, skipping")
+		return
+	}
+
+	names := strings.Split(fullname, " ")
+	firstname := names[0]
+	lastname := "lastname_not_found"
+	if len(names) > 1 {
+		lastname = names[1]
+	}
+
+	log.Info("zohoInsertLead", zap.String("firstname", firstname), zap.String("lastname", lastname), zap.String("email", email))
+
+	type zohoLeadInsertData struct {
+		LeadSource string `json:"Lead_Source"`
+		LastName   string `json:"Last_Name"`
+		FirstName  string `json:"First_Name"`
+		Email      string `json:"Email"`
+	}
+
+	type zohoLeadInsertRequest struct {
+		Data []zohoLeadInsertData `json:"data"`
+	}
+
+	reqBody := &zohoLeadInsertRequest{
+		Data: []zohoLeadInsertData{
+			{
+				LeadSource: zoho_DefaultLeadSource,
+				LastName:   lastname,
+				FirstName:  firstname,
+				Email:      email,
+			},
+		},
+	}
+
+	b, err := json.Marshal(reqBody)
+	if err != nil {
+		log.Error("zohoInsertLead: json.Marshal", zap.Error(err))
+		return
+	}
+
+	client := &http.Client{}
+
+	req, err := http.NewRequest(http.MethodPost, "https://www.zohoapis.in/crm/v2/Leads", bytes.NewReader(b))
+	if err != nil {
+		log.Error("zohoInsertLead: http.NewRequest", zap.Error(err))
+		return
+	}
+
+	req.Header.Add("Authorization", "Bearer "+token.String())
+
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Error("zohoInsertLead: client.Do", zap.Error(err))
+		return
+	}
+	defer resp.Body.Close()
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Error("zohoInsertLead: io.ReadAll", zap.Error(err))
+		return
+	}
+
+	fmt.Println("zohoInsertLead:", resp.StatusCode, string(data))
+
+	if resp.StatusCode != http.StatusCreated {
+		log.Error("zohoInsertLead: resp.StatusCode != http.StatusOK", zap.Int("status", resp.StatusCode))
+		return
+	}
+
+	log.Info("zohoInsertLead: success")
+
+}


### PR DESCRIPTION
What: 
Logic for zoho lead insert API on user registration.

Why:

Please describe the tests:
 - Test 1: Register user from marketing page and should insert lead in zoho.
 
Please describe the performance impact:
This zoho push we are doing on go routine which is not blocking registration flow so no impact on registration time.

## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
